### PR TITLE
fix build script , as without this fix it fails to build.

### DIFF
--- a/utils/build.sh
+++ b/utils/build.sh
@@ -17,7 +17,7 @@ CMD_CHECK "mkdir dist/www"
 CMD_CHECK "echo UP AND RUNNING > dist/www/index.html"
 CMD_CHECK "cp -rv ${ROOT_DIR}/src/frontend/* dist/www"
 CMD_CHECK "cp -rv ${ROOT_DIR}/src/data dist/"
-CMD_CHECK "cp -rv ${ROOT_DIR}/docs/manual dist/www/"
+CMD_CHECK "cp -rv ${ROOT_DIR}/src/docs/manual dist/www/"
 echo "dist ready."
 
 ###############################################################################


### PR DESCRIPTION
without this fix, I got this error very early in the initial setup. 

Executing: cp -rv /Users/buzz/UAV/planner/utils/..//docs/manual dist/www/ 
cp: /Users/buzz/UAV/planner/utils/..//docs/manual: No such file or directory

FATAL: request failed; exiting. 

